### PR TITLE
Adding alias method verification for call

### DIFF
--- a/spec/dry/data/constrained_spec.rb
+++ b/spec/dry/data/constrained_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Dry::Data::Constrained do
     it 'raises when a given constraint is violated' do
       expect { type['he'] }.to raise_error(Dry::Data::ConstraintError, /he/)
     end
+
+    it 'is aliased as #call' do
+      expect(type.call('hello')).to eql('hello')
+    end
   end
 
   context 'with a sum type' do

--- a/spec/dry/data/default_spec.rb
+++ b/spec/dry/data/default_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Dry::Data::Type, '#default' do
     expect(type[nil]).to eql('foo')
   end
 
+  it 'aliases #[] as #call' do
+    expect(type.call(nil)).to eql('foo')
+  end
+
   it 'returns original value when it is not nil' do
     expect(type['bar']).to eql('bar')
   end

--- a/spec/dry/data/enum_spec.rb
+++ b/spec/dry/data/enum_spec.rb
@@ -21,4 +21,9 @@ RSpec.describe Dry::Data::Enum do
 
     expect(type.values).to be_frozen
   end
+
+  it 'aliases #[] as #call' do
+    expect(type.call('draft')).to eql(values[0])
+    expect(type.call(0)).to eql(values[0])
+  end
 end

--- a/spec/dry/data/safe_spec.rb
+++ b/spec/dry/data/safe_spec.rb
@@ -9,4 +9,8 @@ RSpec.describe Dry::Data::Type, '#safe' do
   it 'skips constructor when primitive does not match' do
     expect(type[:passing]).to be(:passing)
   end
+
+  it 'aliases #[] as #call' do
+    expect(type.call(:passing)).to be(:passing)
+  end
 end

--- a/spec/dry/data/sum_type_spec.rb
+++ b/spec/dry/data/sum_type_spec.rb
@@ -24,5 +24,11 @@ RSpec.describe Dry::Data::SumType do
 
       expect { type[{}] }.to raise_error(TypeError)
     end
+
+    it 'is aliased as #call' do
+      type = Dry::Data['int'] | Dry::Data['string']
+      expect(type.call(312)).to be(312)
+      expect(type.call('312')).to eql('312')
+    end
   end
 end

--- a/spec/dry/data/sum_type_spec.rb
+++ b/spec/dry/data/sum_type_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Dry::Data::SumType do
-  describe '#call' do
+  describe '#[]' do
     it 'works with two pass-through types' do
       type = Dry::Data['int'] | Dry::Data['string']
 

--- a/spec/dry/data/type/optional_spec.rb
+++ b/spec/dry/data/type/optional_spec.rb
@@ -8,4 +8,8 @@ RSpec.describe Dry::Data::Type, '#optional' do
   it 'returns Some when value exists' do
     expect(type['hello'].value).to eql('hello')
   end
+
+  it 'aliases #[] as #call' do
+    expect(type.call('hello').value).to eql('hello')
+  end
 end

--- a/spec/dry/data/type_spec.rb
+++ b/spec/dry/data/type_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Dry::Data::Type do
       expect { Dry::Data["strict.date"]['nopenopenope'] }
         .to raise_error(Dry::Data::ConstraintError, /"nopenopenope" violates constraints/)
     end
+
+    it 'is aliased as #call' do
+      expect(string.call('hello')).to eql('hello')
+    end
   end
 
   describe 'with Bool' do


### PR DESCRIPTION
## Updating spec desc to reflect tested method

@326bb2d649d94bb104ed99e96b8283cb48b25e62

The description of the spec stated it was testing #call yet the specs
were instead testing #[]. This change brings the spec description more
inline with other specs for #[].

## Adding alias_method tests for #call

@48707ab41b5a00ae3f49730c6169f33023b20d06

While the method is defined in #call the specs are testing the alias
of #[].

For the projects I'm considering using dry-data, I find the #call idiom to be
more inline with the projects existing idioms. So I want to see specs that
assert #call is part of the public interface and expectation.
